### PR TITLE
Redirection / -> liste projet -> wiki

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,3 +4,12 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libmysqlclient-dev  build-essential \
     && rm -rf /var/lib/apt/lists/*
+
+# Apply patch so that:
+# - default / page will list projects
+# - listed project links will jump to project's wiki page
+COPY home-to-project-index.patch project-hierarchy-jump-to-wiki.patch /usr/src/redmine/
+RUN cd /usr/src/redmine/ \
+    && patch -p1 -E < home-to-project-index.patch \
+    && patch -p1 -E < project-hierarchy-jump-to-wiki.patch 
+

--- a/docker/home-to-project-index.patch
+++ b/docker/home-to-project-index.patch
@@ -1,0 +1,12 @@
+diff -uwr a/config/routes.rb b/config/routes.rb
+--- a/config/routes.rb	2015-09-20 08:20:45.000000000 +0200
++++ b/config/routes.rb	2017-03-24 23:03:31.713642401 +0100
+@@ -16,7 +16,7 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ 
+ Rails.application.routes.draw do
+-  root :to => 'welcome#index', :as => 'home'
++  root :to => 'projects#index', :as => 'home'
+ 
+   match 'login', :to => 'account#login', :as => 'signin', :via => [:get, :post]
+   match 'logout', :to => 'account#logout', :as => 'signout', :via => [:get, :post]

--- a/docker/project-hierarchy-jump-to-wiki.patch
+++ b/docker/project-hierarchy-jump-to-wiki.patch
@@ -1,0 +1,12 @@
+diff -uwr a/app/helpers/projects_helper.rb b/app/helpers/projects_helper.rb
+--- a/app/helpers/projects_helper.rb	2015-09-20 08:20:43.000000000 +0200
++++ b/app/helpers/projects_helper.rb	2017-03-24 23:04:03.265306002 +0100
+@@ -64,7 +64,7 @@
+   # Renders the projects index
+   def render_project_hierarchy(projects)
+     render_project_nested_lists(projects) do |project|
+-      s = link_to_project(project, {}, :class => "#{project.css_classes} #{User.current.member_of?(project) ? 'my-project' : nil}")
++      s = link_to_project(project, { :jump => "wiki" }, :class => "#{project.css_classes} #{User.current.member_of?(project) ? 'my-project' : nil}")
+       if project.description.present?
+         s << content_tag('div', textilizable(project.short_description, :project => project), :class => 'wiki description')
+       end


### PR DESCRIPTION
La page par défaut du redmine n'affiche pas grand chose d’intéressant.
Je propose de la rediriger vers la liste des projets.

De même la page par défaut d'un projet (Aperçu) est trop compliquée et
pas si utile que ça. Je propose que qunad on clique sur un projet ça
redirige plutot vers le wiki du projet, que les gens peuvent adapter
facilement à leurs besoins.
